### PR TITLE
codama_dfu_i2cコマンドでエラーが出る問題への対処

### DIFF
--- a/codama-rpi-setup/setup.sh
+++ b/codama-rpi-setup/setup.sh
@@ -149,10 +149,14 @@ else
   sudo cp -p ../utils/codama_usb /usr/local/bin/codama_usb
 fi
 
-# Use latest libreadline instead of the one codama_dfu_i2c depends on. See #issue1
-LATEST_LIB_READLINE_PATH=$(find /lib/ -name "libreadline.so*" | sort | tail -1)
-LIB_READLINE_DIR=$(dirname $LATEST_LIB_READLINE_PATH)
-sudo ln -s $LATEST_LIB_READLINE_PATH $LIB_READLINE_DIR/libreadline.so.7
+REQUIRED_LIB_READLINE="libreadline.so.7"
+REQUIRED_LIB_READLINE_PATH=$(find /lib/ -name $REQUIRED_LIB_READLINE)
+if [ -z "$REQUIRED_LIB_READLINE_PATH" ]; then # if the version of libreadline.so codama_dfu_i2c requires does not exsist
+    # Use latest libreadline instead. See #issue1
+    LATEST_LIB_READLINE_PATH=$(find /lib/ -name "libreadline.so*" | sort | tail -1)
+    LIB_READLINE_DIR=$(dirname $LATEST_LIB_READLINE_PATH)
+    sudo ln -s $LATEST_LIB_READLINE_PATH $LIB_READLINE_DIR/$REQUIRED_LIB_READLINE
+fi
 
 echo "To enable I2S and I2C, this Raspberry Pi must be rebooted."
 

--- a/codama-rpi-setup/setup.sh
+++ b/codama-rpi-setup/setup.sh
@@ -149,6 +149,11 @@ else
   sudo cp -p ../utils/codama_usb /usr/local/bin/codama_usb
 fi
 
+# Use latest libreadline instead of the one codama_dfu_i2c depends on. See #issue1
+LATEST_LIB_READLINE_PATH=$(find /lib/ -name "libreadline.so*" | sort | tail -1)
+LIB_READLINE_DIR=$(dirname $LATEST_LIB_READLINE_PATH)
+sudo ln -s $LATEST_LIB_READLINE_PATH $LIB_READLINE_DIR/libreadline.so.7
+
 echo "To enable I2S and I2C, this Raspberry Pi must be rebooted."
 
 popd > /dev/null


### PR DESCRIPTION
- #1 
  - Raspberry Pi OSのversionによっては、codama_dfu_i2cの依存関係にあるライブラリのversion違いにより、エラーが発生するため、その対応を行なった
  - 具体的な内容としては、libreadlinesのライブラリファイルを探索して、最新版のシンボリックリンクをcodama_dfu_i2cが使用しているversionとして作成した
