### PR TITLE
kernel version6 への対応

### DIFF
--- a/codama-rpi-setup/setup.sh
+++ b/codama-rpi-setup/setup.sh
@@ -77,7 +77,7 @@ sudo /etc/init.d/alsa-utils restart
 
 
 # Configure the I2C - disable the default built-in driver
-if [ "`uname -r | cut -d. -f1`" != "5" ] ; then
+if [ "`uname -r | cut -d. -f1`" -le "4" ] ; then
     sudo sed -i -e 's/#\?dtparam=i2c_arm=on/dtparam=i2c_arm=off/' /boot/config.txt
     if ! grep -q "i2c-bcm2708" /etc/modules-load.d/modules.conf; then
         sudo sh -c 'echo i2c-bcm2708 >> /etc/modules-load.d/modules.conf'
@@ -130,7 +130,7 @@ fi
 
 # setup Utils
 if [ "`uname -m`" = "aarch64" ] ; then
-  if [ "`uname -r | cut -d. -f1`" != "5" ] ; then
+  if [ "`uname -r | cut -d. -f1`" -le "4" ] ; then
     sudo cp -p ../utils/codama_i2c-64 /usr/local/bin/codama_i2c
     sudo cp -p ../utils/codama_dfu_i2c-64 /usr/local/bin/codama_dfu_i2c
   else
@@ -139,7 +139,7 @@ if [ "`uname -m`" = "aarch64" ] ; then
   fi
   sudo cp -p ../utils/codama_usb-64 /usr/local/bin/codama_usb
 else
-  if [ "`uname -r | cut -d. -f1`" != "5" ] ; then
+  if [ "`uname -r | cut -d. -f1`" -le "4" ] ; then
     sudo cp -p ../utils/codama_i2c /usr/local/bin/codama_i2c
     sudo cp -p ../utils/codama_dfu_i2c /usr/local/bin/codama_dfu_i2c
   else


### PR DESCRIPTION
- カーネルのversionが4から5になった際に行った対応が、version6になって適応できなくなったのを修正
  - 条件文を "カーネルのversionが5かそれ以外か" から "カーネルのversionが4以下かそれ以外か" に変更
- この対応により、#6 が解決する